### PR TITLE
Ignoring tools-versions file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules
 
 # Desktop Services Store on macOS
 .DS_Store
+
+# Asdf versions file
+.tool-versions


### PR DESCRIPTION
Supposing we're using [asdf](https://github.com/asdf-vm/asdf), we need to ignore this type of file.